### PR TITLE
Updated sfdx download / installation routine

### DIFF
--- a/.github/workflows/system-package-version-create.yaml
+++ b/.github/workflows/system-package-version-create.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: "Install Salesforce CLI"
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/system-package-version-create.yaml
+++ b/.github/workflows/system-package-version-create.yaml
@@ -33,10 +33,11 @@ jobs:
 
       - name: "Install Salesforce CLI"
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=./sfdx-cli/bin:$PATH
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/system-package-version-create.yaml
+++ b/.github/workflows/system-package-version-create.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx update
 

--- a/.github/workflows/system-scratch-org-create.yaml
+++ b/.github/workflows/system-scratch-org-create.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx update
 

--- a/.github/workflows/system-scratch-org-create.yaml
+++ b/.github/workflows/system-scratch-org-create.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch != 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/system-scratch-org-create.yaml
+++ b/.github/workflows/system-scratch-org-create.yaml
@@ -33,10 +33,11 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch != 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=./sfdx-cli/bin:$PATH
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/system-scratch-org-delete.yaml
+++ b/.github/workflows/system-scratch-org-delete.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: "Install Salesforce CLI"
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/system-scratch-org-delete.yaml
+++ b/.github/workflows/system-scratch-org-delete.yaml
@@ -39,10 +39,11 @@ jobs:
 
       - name: "Install Salesforce CLI"
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=./sfdx-cli/bin:$PATH
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/system-scratch-org-delete.yaml
+++ b/.github/workflows/system-scratch-org-delete.yaml
@@ -41,7 +41,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx update
 

--- a/.github/workflows/system-test-apex-tests.yaml
+++ b/.github/workflows/system-test-apex-tests.yaml
@@ -47,10 +47,11 @@ jobs:
       - name: "Install Salesforce CLI"
         if: (steps.get_apex_test_setting.outputs.run_apex-tests == 'true') || (steps.get_apex_test_setting.outputs.run_apex-tests == true)
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=./sfdx-cli/bin:$PATH
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx plugins:install texei-sfdx-plugin
           sfdx update
 

--- a/.github/workflows/system-test-apex-tests.yaml
+++ b/.github/workflows/system-test-apex-tests.yaml
@@ -49,7 +49,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx plugins:install texei-sfdx-plugin
           sfdx update

--- a/.github/workflows/system-test-apex-tests.yaml
+++ b/.github/workflows/system-test-apex-tests.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: "Install Salesforce CLI"
         if: (steps.get_apex_test_setting.outputs.run_apex-tests == 'true') || (steps.get_apex_test_setting.outputs.run_apex-tests == true)
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/system-test-code-scan.yaml
+++ b/.github/workflows/system-test-code-scan.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: "Install Salesforce CLI"
         if: (steps.get_scanner_setting.outputs.run_sfdx_scanner == 'true') || (steps.get_scanner_setting.outputs.run_sfdx_scanner == true)
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/system-test-code-scan.yaml
+++ b/.github/workflows/system-test-code-scan.yaml
@@ -43,10 +43,11 @@ jobs:
       - name: "Install Salesforce CLI"
         if: (steps.get_scanner_setting.outputs.run_sfdx_scanner == 'true') || (steps.get_scanner_setting.outputs.run_sfdx_scanner == true)
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=./sfdx-cli/bin:$PATH
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 
       - name: "Install SFDX Plugins"

--- a/.github/workflows/system-test-code-scan.yaml
+++ b/.github/workflows/system-test-code-scan.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx update
 

--- a/.github/workflows/user-package-managed-create.yaml
+++ b/.github/workflows/user-package-managed-create.yaml
@@ -33,10 +33,11 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch == 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=./sfdx-cli/bin:$PATH
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/user-package-managed-create.yaml
+++ b/.github/workflows/user-package-managed-create.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx update
 

--- a/.github/workflows/user-package-managed-create.yaml
+++ b/.github/workflows/user-package-managed-create.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch == 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/user-package-unlocked-create.yaml
+++ b/.github/workflows/user-package-unlocked-create.yaml
@@ -33,10 +33,11 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch == 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=./sfdx-cli/bin:$PATH
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/user-package-unlocked-create.yaml
+++ b/.github/workflows/user-package-unlocked-create.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx update
 

--- a/.github/workflows/user-package-unlocked-create.yaml
+++ b/.github/workflows/user-package-unlocked-create.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch == 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/user-package-unlocked-orgdependent-create.yaml
+++ b/.github/workflows/user-package-unlocked-orgdependent-create.yaml
@@ -33,10 +33,11 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch == 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=./sfdx-cli/bin:$PATH
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/user-package-unlocked-orgdependent-create.yaml
+++ b/.github/workflows/user-package-unlocked-orgdependent-create.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx update
 

--- a/.github/workflows/user-package-unlocked-orgdependent-create.yaml
+++ b/.github/workflows/user-package-unlocked-orgdependent-create.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch == 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/user-package-version-promote.yaml
+++ b/.github/workflows/user-package-version-promote.yaml
@@ -39,10 +39,11 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch == 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=./sfdx-cli/bin:$PATH
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/user-package-version-promote.yaml
+++ b/.github/workflows/user-package-version-promote.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch == 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/user-package-version-promote.yaml
+++ b/.github/workflows/user-package-version-promote.yaml
@@ -41,7 +41,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx update
 

--- a/.github/workflows/user-readme-build.yaml
+++ b/.github/workflows/user-readme-build.yaml
@@ -33,8 +33,7 @@ jobs:
           wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          echo $PATH
-          export PATH=./sfdx-cli/bin:$PATH
+          ln -s ./sfdx-cli/bin/sfdx /usr/local/bin/sfdx
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/user-readme-build.yaml
+++ b/.github/workflows/user-readme-build.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: "Install Salesforce CLI"
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/user-readme-build.yaml
+++ b/.github/workflows/user-readme-build.yaml
@@ -33,6 +33,7 @@ jobs:
           wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
+          echo $PATH
           export PATH=./sfdx-cli/bin:$PATH
           sfdx update
 

--- a/.github/workflows/user-readme-build.yaml
+++ b/.github/workflows/user-readme-build.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx update
 

--- a/.github/workflows/user-readme-build.yaml
+++ b/.github/workflows/user-readme-build.yaml
@@ -33,6 +33,7 @@ jobs:
           wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
+          export PATH=./sfdx-cli/bin:$PATH
           echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 

--- a/.github/workflows/user-readme-build.yaml
+++ b/.github/workflows/user-readme-build.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: "Install Salesforce CLI"
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           export PATH=~/sfdx-cli/bin:$PATH

--- a/.github/workflows/user-readme-build.yaml
+++ b/.github/workflows/user-readme-build.yaml
@@ -33,7 +33,7 @@ jobs:
           wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          export PATH=~/sfdx-cli/bin:$PATH
+          export PATH=./sfdx-cli/bin:$PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/user-readme-build.yaml
+++ b/.github/workflows/user-readme-build.yaml
@@ -33,7 +33,7 @@ jobs:
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          export PATH=~/sfdx/bin:$PATH
+          export PATH=~/sfdx-cli/bin:$PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/user-readme-build.yaml
+++ b/.github/workflows/user-readme-build.yaml
@@ -33,7 +33,7 @@ jobs:
           wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ln -s ./sfdx-cli/bin/sfdx /usr/local/bin/sfdx
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/user-readme-build.yaml
+++ b/.github/workflows/user-readme-build.yaml
@@ -33,7 +33,7 @@ jobs:
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=~/sfdx/bin:$PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/user-scratch-org-create.yaml
+++ b/.github/workflows/user-scratch-org-create.yaml
@@ -38,10 +38,11 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch != 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=./sfdx-cli/bin:$PATH
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/user-scratch-org-create.yaml
+++ b/.github/workflows/user-scratch-org-create.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx update
 

--- a/.github/workflows/user-scratch-org-create.yaml
+++ b/.github/workflows/user-scratch-org-create.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch != 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/user-scratch-org-dependencies-install.yaml
+++ b/.github/workflows/user-scratch-org-dependencies-install.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch != 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/user-scratch-org-dependencies-install.yaml
+++ b/.github/workflows/user-scratch-org-dependencies-install.yaml
@@ -39,10 +39,11 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch != 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=./sfdx-cli/bin:$PATH
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/user-scratch-org-dependencies-install.yaml
+++ b/.github/workflows/user-scratch-org-dependencies-install.yaml
@@ -41,7 +41,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx update
 

--- a/.github/workflows/user-scratch-org-pull.yaml
+++ b/.github/workflows/user-scratch-org-pull.yaml
@@ -38,10 +38,11 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch != 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=./sfdx-cli/bin:$PATH
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"

--- a/.github/workflows/user-scratch-org-pull.yaml
+++ b/.github/workflows/user-scratch-org-pull.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx update
 

--- a/.github/workflows/user-scratch-org-pull.yaml
+++ b/.github/workflows/user-scratch-org-pull.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch != 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/user-scratch-org-push.yaml
+++ b/.github/workflows/user-scratch-org-push.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
-          tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
+          tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install
           sfdx update
 

--- a/.github/workflows/user-scratch-org-push.yaml
+++ b/.github/workflows/user-scratch-org-push.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch != 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
+          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-amd64.tar.xz -C sfdx-cli --strip-components 1
           ./sfdx-cli/install

--- a/.github/workflows/user-scratch-org-push.yaml
+++ b/.github/workflows/user-scratch-org-push.yaml
@@ -33,10 +33,11 @@ jobs:
       - name: "Install Salesforce CLI"
         if: ${{ steps.extract_branch_name.outputs.branch != 'master' }}
         run: |
-          wget https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
+          wget -nv https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz
           mkdir sfdx-cli
           tar xJf sfdx-linux-x64.tar.xz -C sfdx-cli --strip-components 1
-          ./sfdx-cli/install
+          export PATH=./sfdx-cli/bin:$PATH
+          echo "./sfdx-cli/bin" >> $GITHUB_PATH
           sfdx update
 
       - name: "Populate auth file with DEVHUB_AUTH_URL secret"


### PR DESCRIPTION
Updated the download URL for sfdx to a more recent one, so that subsequent updates should become faster.
The installation routine that was present in the old version doesn't exist any more, so instead, we're adding the downloaded directory to PATH.
Additionally, I made wget a bit less talkative.