### PR TITLE
Added .sf directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Salesforce cache
 .sfdx/
+.sf/
 .localdevserver/
 
 # LWC VSCode autocomplete


### PR DESCRIPTION
Recently, sfdx(?) introduced a new directory to store some configuration after a scratch org was created. This configuration does not affect the code itself but your local development environment, so it shouldn't be versioned.